### PR TITLE
Remove --no-site-packages from README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can retrieve settings in templates:
 ## Testing
 ```bash
 # create python 3.7 virtual environment
-virtualenv testing_django_extra_settings -p "python3.7" --no-site-packages
+virtualenv testing_django_extra_settings -p "python3.7"
 
 # activate virtualenv
 cd testing_django_extra_settings && . bin/activate


### PR DESCRIPTION
--no-site-packages is the default for old virtualenv versions and is removed from newer versions.
See https://stackoverflow.com/a/60783839/7710928