### PR TITLE
fix #194: use formfield_callback to assume HTTPS scheme

### DIFF
--- a/extra_settings/forms.py
+++ b/extra_settings/forms.py
@@ -1,4 +1,4 @@
-from django import forms
+from django import VERSION, forms
 from django.conf import settings
 from django.db import models
 
@@ -6,12 +6,12 @@ from extra_settings.models import Setting
 from extra_settings.utils import enforce_uppercase_setting
 
 
-def urlfields_assume_https(field, **kwargs):
+def urlfields_assume_scheme(field, **kwargs):
     """
-    ModelForm.Meta.formfield_callback function to assume HTTPS for scheme-less
-    domains in URLFields.
+    ModelForm.Meta.formfield_callback function to set assume_scheme for scheme-less
+    domains in URLFields. Only since Django version 5.0.
     """
-    if isinstance(field, models.URLField):
+    if isinstance(field, models.URLField) and VERSION >= (5, 0):
         kwargs["assume_scheme"] = "https"
 
     return field.formfield(**kwargs)
@@ -21,7 +21,7 @@ class SettingForm(forms.ModelForm):
     class Meta:
         model = Setting
         fields = "__all__"
-        formfield_callback = urlfields_assume_https
+        formfield_callback = urlfields_assume_scheme
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.test import TestCase
 
 from extra_settings.forms import SettingForm
@@ -35,7 +36,7 @@ class ExtraSettingsFormsTestCase(TestCase):
         form_obj = SettingForm(data=form_data)
         self.assertTrue(form_obj.is_valid())
 
-    def test_form_with_auto_https_url(self):
+    def test_form_assume_scheme(self):
         form_data = {
             "name": "PACKAGE_NAME",
             "value_type": Setting.TYPE_URL,
@@ -44,4 +45,8 @@ class ExtraSettingsFormsTestCase(TestCase):
         }
         form_obj = SettingForm(data=form_data)
         self.assertTrue(form_obj.is_valid())
-        self.assertEqual(form_obj.cleaned_data["value_url"], "https://example.com")
+
+        if VERSION >= (5, 0):
+            self.assertEqual(form_obj.cleaned_data["value_url"], "https://example.com")
+        else:
+            self.assertEqual(form_obj.cleaned_data["value_url"], "http://example.com")


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
In SettingForm's Meta class, use the "formfield_callback" to apply the "assume_scheme" option on potential URLField.

**Related issue**
#194 

**Checklist before requesting a review**
- [X] I have performed a self-review of my code.
- [X] I have added tests for the proposed changes.
- [X] I have run the tests and there are not errors.
