### PR TITLE
Extract field types into a SettingType enum importable from settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ EXTRA_SETTINGS_CACHE_NAME = "extra_settings"
 ```
 
 ```python
+from extra_settings.choices import SettingType
+
 # a list of settings that will be available by default, each item must contain "name", "type" and "value".
 # check the #types section to see all the supported settings types.
 EXTRA_SETTINGS_DEFAULTS = [
     {
         "name": "SETTING_NAME",
-        "type": "string",
+        "type": SettingType.STRING,
         "value": "Hello World",
     },
     # ...
@@ -150,23 +152,36 @@ By default the `"extra_settings"` cache is used, if you want to use another cach
 You can **create**, **read**, **update** and **delete** settings programmatically:
 
 #### Types
-This is the list of the currently supported setting types you may need to use:
+Setting types are available as a `TextChoices` enum in `extra_settings.choices`.
+Unlike `Setting.TYPE_*`, it can be imported anywhere (including your `settings.py`)
+without triggering `AppRegistryNotReady`:
 
--   `Setting.TYPE_BOOL`
--   `Setting.TYPE_DATE`
--   `Setting.TYPE_DATETIME`
--   `Setting.TYPE_DECIMAL`
--   `Setting.TYPE_DURATION`
--   `Setting.TYPE_EMAIL`
--   `Setting.TYPE_FILE`
--   `Setting.TYPE_FLOAT`
--   `Setting.TYPE_IMAGE`
--   `Setting.TYPE_INT`
--   `Setting.TYPE_JSON`
--   `Setting.TYPE_STRING`
--   `Setting.TYPE_TEXT`
--   `Setting.TYPE_TIME`
--   `Setting.TYPE_URL`
+```python
+from extra_settings.choices import SettingType
+
+SettingType.STRING  # == "string"
+```
+
+This is the list of the currently supported setting types:
+
+-   `SettingType.BOOL`
+-   `SettingType.DATE`
+-   `SettingType.DATETIME`
+-   `SettingType.DECIMAL`
+-   `SettingType.DURATION`
+-   `SettingType.EMAIL`
+-   `SettingType.FILE`
+-   `SettingType.FLOAT`
+-   `SettingType.IMAGE`
+-   `SettingType.INT`
+-   `SettingType.JSON`
+-   `SettingType.STRING`
+-   `SettingType.TEXT`
+-   `SettingType.TIME`
+-   `SettingType.URL`
+
+> The `Setting.TYPE_*` constants (e.g. `Setting.TYPE_STRING`) remain available as
+> aliases for backward compatibility.
 
 #### Create
 ```python

--- a/extra_settings/choices.py
+++ b/extra_settings/choices.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+
+class SettingType(models.TextChoices):
+    BOOL = "bool", "bool"
+    DATE = "date", "date"
+    DATETIME = "datetime", "datetime"
+    DECIMAL = "decimal", "decimal"
+    DURATION = "duration", "duration"
+    EMAIL = "email", "email"
+    FILE = "file", "file"
+    FLOAT = "float", "float"
+    IMAGE = "image", "image"
+    INT = "int", "int"
+    JSON = "json", "json"
+    STRING = "string", "string"
+    TEXT = "text", "text"
+    TIME = "time", "time"
+    URL = "url", "url"
+    # COLOR = "color", "color"  # TODO
+    # HTML = "html", "html"     # TODO
+    # UUID = "uuid", "uuid"     # TODO

--- a/extra_settings/models.py
+++ b/extra_settings/models.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from extra_settings import fields
 from extra_settings.cache import get_cached_setting, set_cached_setting
+from extra_settings.choices import SettingType
 from extra_settings.utils import enforce_uppercase_setting, import_function
 
 
@@ -104,45 +105,23 @@ class Setting(models.Model):
     def set_defaults_from_settings(cls, *args, **kwargs):
         cls.set_defaults(settings.EXTRA_SETTINGS_DEFAULTS)
 
-    TYPE_BOOL = "bool"
-    # TYPE_COLOR = "color" # TODO
-    TYPE_DATE = "date"
-    TYPE_DATETIME = "datetime"
-    TYPE_DECIMAL = "decimal"
-    TYPE_DURATION = "duration"
-    TYPE_EMAIL = "email"
-    TYPE_FILE = "file"
-    TYPE_FLOAT = "float"
-    # TYPE_HTML = "html"
-    TYPE_IMAGE = "image"
-    TYPE_INT = "int"
-    TYPE_JSON = "json"
-    TYPE_STRING = "string"
-    TYPE_TEXT = "text"
-    TYPE_TIME = "time"
-    # TYPE_UUID = "uuid" # TODO
-    TYPE_URL = "url"
+    TYPE_BOOL = SettingType.BOOL
+    TYPE_DATE = SettingType.DATE
+    TYPE_DATETIME = SettingType.DATETIME
+    TYPE_DECIMAL = SettingType.DECIMAL
+    TYPE_DURATION = SettingType.DURATION
+    TYPE_EMAIL = SettingType.EMAIL
+    TYPE_FILE = SettingType.FILE
+    TYPE_FLOAT = SettingType.FLOAT
+    TYPE_IMAGE = SettingType.IMAGE
+    TYPE_INT = SettingType.INT
+    TYPE_JSON = SettingType.JSON
+    TYPE_STRING = SettingType.STRING
+    TYPE_TEXT = SettingType.TEXT
+    TYPE_TIME = SettingType.TIME
+    TYPE_URL = SettingType.URL
 
-    TYPE_CHOICES = (
-        (TYPE_BOOL, TYPE_BOOL),
-        # (TYPE_COLOR, TYPE_COLOR, ),
-        (TYPE_DATE, TYPE_DATE),
-        (TYPE_DATETIME, TYPE_DATETIME),
-        (TYPE_DECIMAL, TYPE_DECIMAL),
-        (TYPE_DURATION, TYPE_DURATION),
-        (TYPE_EMAIL, TYPE_EMAIL),
-        (TYPE_FILE, TYPE_FILE),
-        (TYPE_FLOAT, TYPE_FLOAT),
-        # (TYPE_HTML, TYPE_HTML, ),
-        (TYPE_IMAGE, TYPE_IMAGE),
-        (TYPE_INT, TYPE_INT),
-        (TYPE_JSON, TYPE_JSON),
-        (TYPE_STRING, TYPE_STRING),
-        (TYPE_TEXT, TYPE_TEXT),
-        (TYPE_TIME, TYPE_TIME),
-        # (TYPE_UUID, TYPE_UUID, ),
-        (TYPE_URL, TYPE_URL),
-    )
+    TYPE_CHOICES = SettingType.choices
 
     name = models.CharField(
         max_length=255,
@@ -152,7 +131,7 @@ class Setting(models.Model):
     )
     value_type = models.CharField(
         max_length=20,
-        choices=TYPE_CHOICES,
+        choices=SettingType.choices,
         verbose_name=_(
             "Type",
         ),

--- a/extra_settings/models.py
+++ b/extra_settings/models.py
@@ -121,7 +121,7 @@ class Setting(models.Model):
     TYPE_TIME = SettingType.TIME
     TYPE_URL = SettingType.URL
 
-    TYPE_CHOICES = SettingType.choices
+    TYPE_CHOICES = tuple(SettingType.choices)
 
     name = models.CharField(
         max_length=255,

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -56,3 +56,18 @@ class SettingTypeBackwardCompatTestCase(TestCase):
 
     def test_type_choices_alias_matches_enum(self):
         self.assertEqual(list(Setting.TYPE_CHOICES), list(SettingType.choices))
+
+    def test_set_defaults_accepts_settingtype_member(self):
+        Setting.set_defaults(
+            [
+                {
+                    "name": "TEST_DEFAULTS_SETTINGTYPE",
+                    "type": SettingType.STRING,
+                    "value": "hello",
+                }
+            ]
+        )
+        setting_obj = Setting.objects.get(name="TEST_DEFAULTS_SETTINGTYPE")
+        self.assertEqual(setting_obj.value_type, SettingType.STRING)
+        self.assertEqual(setting_obj.value_type, "string")
+        self.assertEqual(setting_obj.value, "hello")

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,4 +1,7 @@
 import os
+import subprocess
+import sys
+from pathlib import Path
 
 from django.test import TestCase
 
@@ -37,10 +40,25 @@ class SettingTypeChoicesTestCase(TestCase):
         self.assertEqual(list(SettingType.choices), expected)
 
     def test_importable_without_app_registry(self):
-        # importing the module must not require django.setup(); this is the
-        # AppRegistryNotReady scenario from issue #201.
-        self.assertTrue(os.environ.get("DJANGO_SETTINGS_MODULE"))
-        self.assertEqual(SettingType.STRING, "string")
+        # Importing the choices module must not require django.setup(); this is
+        # the AppRegistryNotReady scenario from issue #201. Run in a fresh
+        # subprocess with no DJANGO_SETTINGS_MODULE so this test run's already
+        # initialized app registry can't mask a regression.
+        repo_root = Path(__file__).resolve().parent.parent
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from extra_settings.choices import SettingType; "
+                "assert SettingType.STRING == 'string'",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 class SettingTypeBackwardCompatTestCase(TestCase):

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,0 +1,42 @@
+import os
+
+from django.test import TestCase
+
+from extra_settings.choices import SettingType
+
+EXPECTED_TYPES = {
+    "BOOL": "bool",
+    "DATE": "date",
+    "DATETIME": "datetime",
+    "DECIMAL": "decimal",
+    "DURATION": "duration",
+    "EMAIL": "email",
+    "FILE": "file",
+    "FLOAT": "float",
+    "IMAGE": "image",
+    "INT": "int",
+    "JSON": "json",
+    "STRING": "string",
+    "TEXT": "text",
+    "TIME": "time",
+    "URL": "url",
+}
+
+
+class SettingTypeChoicesTestCase(TestCase):
+    def test_member_values_and_labels_are_lowercase(self):
+        for member_name, value in EXPECTED_TYPES.items():
+            with self.subTest(type=member_name):
+                member = getattr(SettingType, member_name)
+                self.assertEqual(member.value, value)
+                self.assertEqual(member.label, value)
+
+    def test_choices_match_expected(self):
+        expected = [(value, value) for value in EXPECTED_TYPES.values()]
+        self.assertEqual(list(SettingType.choices), expected)
+
+    def test_importable_without_app_registry(self):
+        # importing the module must not require django.setup(); this is the
+        # AppRegistryNotReady scenario from issue #201.
+        self.assertTrue(os.environ.get("DJANGO_SETTINGS_MODULE"))
+        self.assertEqual(SettingType.STRING, "string")

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -3,6 +3,7 @@ import os
 from django.test import TestCase
 
 from extra_settings.choices import SettingType
+from extra_settings.models import Setting
 
 EXPECTED_TYPES = {
     "BOOL": "bool",
@@ -40,3 +41,18 @@ class SettingTypeChoicesTestCase(TestCase):
         # AppRegistryNotReady scenario from issue #201.
         self.assertTrue(os.environ.get("DJANGO_SETTINGS_MODULE"))
         self.assertEqual(SettingType.STRING, "string")
+
+
+class SettingTypeBackwardCompatTestCase(TestCase):
+    def test_model_aliases_are_enum_members(self):
+        # identity, not just equality: forces the model to source TYPE_* from the
+        # enum. Before wiring, Setting.TYPE_BOOL is the plain str "bool", which is
+        # NOT the singleton SettingType.BOOL, so assertIs fails.
+        for member_name, value in EXPECTED_TYPES.items():
+            with self.subTest(type=member_name):
+                alias = getattr(Setting, f"TYPE_{member_name}")
+                self.assertIs(alias, getattr(SettingType, member_name))
+                self.assertEqual(alias, value)
+
+    def test_type_choices_alias_matches_enum(self):
+        self.assertEqual(list(Setting.TYPE_CHOICES), list(SettingType.choices))


### PR DESCRIPTION
**Describe your changes**

The field type constants (`TYPE_BOOL` … `TYPE_URL`) and `TYPE_CHOICES` currently live on the `Setting` model. Referencing them from a project's `settings.py` (e.g. in `EXTRA_SETTINGS_DEFAULTS`) therefore requires importing the model, which raises `AppRegistryNotReady`. As a result the defaults have to use raw strings like `"type": "string"`, where typos go undetected.

This PR extracts them into a new standalone `extra_settings/choices.py` module as a `SettingType(models.TextChoices)` enum that imports no model, so it can be used anywhere — including `settings.py` — with typo-safe constants.

- Add `extra_settings.choices.SettingType` (`TextChoices`). Member labels are kept lowercase (`NAME = "value", "value"`) so the admin type dropdown is visually unchanged.
- `Setting.TYPE_*` and `Setting.TYPE_CHOICES` are preserved as backward-compatible aliases (`TYPE_CHOICES` stays a `tuple`). No database migration is required.
- Update the README: document `SettingType` and use `SettingType.STRING` in the `EXTRA_SETTINGS_DEFAULTS` example.

**Related issue**

Closes #201

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
