### PR TITLE
fix: apply EXTRA_SETTINGS defaults robustly (early-import boot break)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1](https://github.com/fabiocaccamo/django-extra-settings/releases/tag/0.15.1) - 2026-07-15
+-   Fix defaults not being applied when importing from the `extra_settings` package inside the settings module (early-import boot break).
+
 ## [0.15.0](https://github.com/fabiocaccamo/django-extra-settings/releases/tag/0.15.0) - 2026-07-13
 -   Add `Python 3.14` support.
 -   Add `Django 6.0` support.

--- a/extra_settings/admin.py
+++ b/extra_settings/admin.py
@@ -4,6 +4,7 @@ from django.contrib.admin.sites import NotRegistered
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
+from extra_settings import settings as extra_settings_conf
 from extra_settings.forms import SettingForm
 from extra_settings.models import Setting
 
@@ -79,10 +80,10 @@ class SettingAdmin(admin.ModelAdmin):
 
     list_filter_items = []
 
-    if settings.EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER:
+    if extra_settings_conf.get("EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER"):
         list_filter_items.append(SettingNamePrefixFilter)
 
-    if settings.EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER:
+    if extra_settings_conf.get("EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER"):
         list_filter_items.append("value_type")
 
     if list_filter_items:
@@ -184,7 +185,7 @@ def register_extra_settings_admin(
 admin.site.register(Setting, SettingAdmin)
 
 
-app = settings.EXTRA_SETTINGS_ADMIN_APP
+app = extra_settings_conf.get("EXTRA_SETTINGS_ADMIN_APP")
 if app and app != "extra_settings":
     register_extra_settings_admin(
         app=app,

--- a/extra_settings/apps.py
+++ b/extra_settings/apps.py
@@ -1,14 +1,17 @@
 from django.apps import AppConfig
-from django.conf import settings
 from django.db.models.signals import post_migrate
+
+from extra_settings import settings as extra_settings_conf
 
 
 class ExtraSettingsConfig(AppConfig):
     name = "extra_settings"
-    verbose_name = settings.EXTRA_SETTINGS_VERBOSE_NAME
+    verbose_name = extra_settings_conf.get("EXTRA_SETTINGS_VERBOSE_NAME")
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        extra_settings_conf.configure_defaults()
+
         from extra_settings import signals  # noqa: F401
         from extra_settings.models import Setting
 

--- a/extra_settings/metadata.py
+++ b/extra_settings/metadata.py
@@ -4,4 +4,4 @@ __description__ = "config and manage typed extra settings using just the django 
 __email__ = "fabio.caccamo@gmail.com"
 __license__ = "MIT"
 __title__ = "django-extra-settings"
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/extra_settings/settings.py
+++ b/extra_settings/settings.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.conf import settings
 
 _CONFIG_DEFAULTS = {
@@ -17,11 +19,15 @@ _CONFIG_DEFAULTS = {
 def configure_defaults():
     for key, value in _CONFIG_DEFAULTS.items():
         if not hasattr(settings, key):
-            setattr(settings, key, value)
+            # deepcopy so mutable defaults (e.g. the EXTRA_SETTINGS_DEFAULTS
+            # list) are never aliased to the canonical _CONFIG_DEFAULTS object.
+            setattr(settings, key, copy.deepcopy(value))
 
 
 def get(key):
-    return getattr(settings, key, _CONFIG_DEFAULTS[key])
+    if hasattr(settings, key):
+        return getattr(settings, key)
+    return copy.deepcopy(_CONFIG_DEFAULTS[key])
 
 
 configure_defaults()

--- a/extra_settings/settings.py
+++ b/extra_settings/settings.py
@@ -1,31 +1,27 @@
 from django.conf import settings
 
-if not hasattr(settings, "EXTRA_SETTINGS_ADMIN_APP"):
-    settings.EXTRA_SETTINGS_ADMIN_APP = "extra_settings"
+_CONFIG_DEFAULTS = {
+    "EXTRA_SETTINGS_ADMIN_APP": "extra_settings",
+    "EXTRA_SETTINGS_CACHE_NAME": "extra_settings",
+    "EXTRA_SETTINGS_DEFAULTS": [],
+    "EXTRA_SETTINGS_ENFORCE_UPPERCASE_SETTINGS": True,
+    "EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS": True,
+    "EXTRA_SETTINGS_FILE_UPLOAD_TO": "files",
+    "EXTRA_SETTINGS_IMAGE_UPLOAD_TO": "images",
+    "EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER": False,
+    "EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER": False,
+    "EXTRA_SETTINGS_VERBOSE_NAME": "Extra Settings",
+}
 
-if not hasattr(settings, "EXTRA_SETTINGS_CACHE_NAME"):
-    settings.EXTRA_SETTINGS_CACHE_NAME = "extra_settings"
 
-if not hasattr(settings, "EXTRA_SETTINGS_DEFAULTS"):
-    settings.EXTRA_SETTINGS_DEFAULTS = []
+def configure_defaults():
+    for key, value in _CONFIG_DEFAULTS.items():
+        if not hasattr(settings, key):
+            setattr(settings, key, value)
 
-if not hasattr(settings, "EXTRA_SETTINGS_ENFORCE_UPPERCASE_SETTINGS"):
-    settings.EXTRA_SETTINGS_ENFORCE_UPPERCASE_SETTINGS = True
 
-if not hasattr(settings, "EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS"):
-    settings.EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS = True
+def get(key):
+    return getattr(settings, key, _CONFIG_DEFAULTS[key])
 
-if not hasattr(settings, "EXTRA_SETTINGS_FILE_UPLOAD_TO"):
-    settings.EXTRA_SETTINGS_FILE_UPLOAD_TO = "files"
 
-if not hasattr(settings, "EXTRA_SETTINGS_IMAGE_UPLOAD_TO"):
-    settings.EXTRA_SETTINGS_IMAGE_UPLOAD_TO = "images"
-
-if not hasattr(settings, "EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER"):
-    settings.EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER = False
-
-if not hasattr(settings, "EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER"):
-    settings.EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER = False
-
-if not hasattr(settings, "EXTRA_SETTINGS_VERBOSE_NAME"):
-    settings.EXTRA_SETTINGS_VERBOSE_NAME = "Extra Settings"
+configure_defaults()

--- a/tests/early_import_settings.py
+++ b/tests/early_import_settings.py
@@ -1,0 +1,25 @@
+# Reproduces the reported boot break: importing from the extra_settings
+# package at the TOP of a settings module, i.e. while django.conf.settings
+# is still being configured.
+from extra_settings.choices import SettingType
+
+SECRET_KEY = "django-extra-settings"
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.admin",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "extra_settings",
+]
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+USE_TZ = True
+
+EXTRA_SETTINGS_DEFAULTS = [
+    {"name": "FOO", "type": SettingType.STRING, "value": "bar"},
+]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+from django.apps import apps as django_apps
 from django.conf import settings
 from django.test import TestCase
 
@@ -62,5 +63,17 @@ class ConfigDefaultsTestCase(TestCase):
         extra_settings_conf.configure_defaults()
         extra_settings_conf.configure_defaults()
         for key, _value in EXPECTED_DEFAULTS.items():
+            with self.subTest(key=key):
+                self.assertTrue(hasattr(settings, key))
+
+
+class AppConfigDefaultsTestCase(TestCase):
+    def test_verbose_name_matches_configured_value(self):
+        app_config = django_apps.get_app_config("extra_settings")
+        self.assertEqual(app_config.verbose_name, settings.EXTRA_SETTINGS_VERBOSE_NAME)
+
+    def test_all_defaults_present_after_ready(self):
+        # ready() has already run for this process; every default must be set.
+        for key in EXPECTED_DEFAULTS:
             with self.subTest(key=key):
                 self.assertTrue(hasattr(settings, key))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -71,6 +71,34 @@ class ConfigDefaultsTestCase(TestCase):
             with self.subTest(key=key):
                 self.assertTrue(hasattr(settings, key))
 
+    def test_configure_defaults_does_not_alias_canonical_mutable(self):
+        # A missing mutable default (the EXTRA_SETTINGS_DEFAULTS list) must be
+        # a fresh copy: mutating what got set on settings must not corrupt the
+        # canonical _CONFIG_DEFAULTS object.
+        key = "EXTRA_SETTINGS_DEFAULTS"
+        original = getattr(settings, key)
+        delattr(settings, key)
+        try:
+            extra_settings_conf.configure_defaults()
+            settings.EXTRA_SETTINGS_DEFAULTS.append("mutated")
+            self.assertEqual(extra_settings_conf._CONFIG_DEFAULTS[key], [])
+        finally:
+            setattr(settings, key, original)
+
+    def test_get_returns_independent_copy_of_missing_mutable(self):
+        # get() on a missing mutable default must return a fresh copy each call,
+        # not the shared canonical object.
+        key = "EXTRA_SETTINGS_DEFAULTS"
+        original = getattr(settings, key)
+        delattr(settings, key)
+        try:
+            first = extra_settings_conf.get(key)
+            first.append("mutated")
+            self.assertEqual(extra_settings_conf.get(key), [])
+            self.assertEqual(extra_settings_conf._CONFIG_DEFAULTS[key], [])
+        finally:
+            setattr(settings, key, original)
+
 
 class AppConfigDefaultsTestCase(TestCase):
     def test_verbose_name_matches_configured_value(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.test import TestCase
@@ -77,3 +82,30 @@ class AppConfigDefaultsTestCase(TestCase):
         for key in EXPECTED_DEFAULTS:
             with self.subTest(key=key):
                 self.assertTrue(hasattr(settings, key))
+
+
+class EarlyImportBootTestCase(TestCase):
+    def test_setup_succeeds_with_early_package_import(self):
+        # Booting Django with a settings module that imports from the
+        # extra_settings package at import time must not break defaults
+        # loading. Run in a fresh subprocess so this run's already-populated
+        # app registry can't mask a regression.
+        repo_root = Path(__file__).resolve().parent.parent
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        env["DJANGO_SETTINGS_MODULE"] = "tests.early_import_settings"
+        script = (
+            "import django; django.setup();"
+            "from django.contrib import admin; admin.autodiscover();"
+            "from django.conf import settings;"
+            "assert settings.EXTRA_SETTINGS_VERBOSE_NAME == 'Extra Settings';"
+            "assert settings.EXTRA_SETTINGS_ADMIN_APP == 'extra_settings';"
+            "assert settings.EXTRA_SETTINGS_ENFORCE_UPPERCASE_SETTINGS is True"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,66 @@
+from django.conf import settings
+from django.test import TestCase
+
+from extra_settings import settings as extra_settings_conf
+
+EXPECTED_DEFAULTS = {
+    "EXTRA_SETTINGS_ADMIN_APP": "extra_settings",
+    "EXTRA_SETTINGS_CACHE_NAME": "extra_settings",
+    "EXTRA_SETTINGS_DEFAULTS": [],
+    "EXTRA_SETTINGS_ENFORCE_UPPERCASE_SETTINGS": True,
+    "EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS": True,
+    "EXTRA_SETTINGS_FILE_UPLOAD_TO": "files",
+    "EXTRA_SETTINGS_IMAGE_UPLOAD_TO": "images",
+    "EXTRA_SETTINGS_SHOW_NAME_PREFIX_LIST_FILTER": False,
+    "EXTRA_SETTINGS_SHOW_TYPE_LIST_FILTER": False,
+    "EXTRA_SETTINGS_VERBOSE_NAME": "Extra Settings",
+}
+
+
+class ConfigDefaultsTestCase(TestCase):
+    def test_config_defaults_match_expected(self):
+        self.assertEqual(extra_settings_conf._CONFIG_DEFAULTS, EXPECTED_DEFAULTS)
+
+    def test_get_returns_default_when_attribute_missing(self):
+        key = "EXTRA_SETTINGS_ADMIN_APP"
+        original = getattr(settings, key)
+        delattr(settings, key)
+        try:
+            self.assertEqual(extra_settings_conf.get(key), "extra_settings")
+        finally:
+            setattr(settings, key, original)
+
+    def test_get_returns_user_value_when_present(self):
+        # tests/settings.py sets EXTRA_SETTINGS_DEFAULTS to a non-empty list.
+        self.assertEqual(
+            extra_settings_conf.get("EXTRA_SETTINGS_DEFAULTS"),
+            settings.EXTRA_SETTINGS_DEFAULTS,
+        )
+        self.assertNotEqual(settings.EXTRA_SETTINGS_DEFAULTS, [])
+
+    def test_configure_defaults_sets_missing_keys(self):
+        key = "EXTRA_SETTINGS_VERBOSE_NAME"
+        original = getattr(settings, key)
+        delattr(settings, key)
+        try:
+            extra_settings_conf.configure_defaults()
+            self.assertEqual(settings.EXTRA_SETTINGS_VERBOSE_NAME, "Extra Settings")
+        finally:
+            setattr(settings, key, original)
+
+    def test_configure_defaults_does_not_overwrite_existing(self):
+        key = "EXTRA_SETTINGS_VERBOSE_NAME"
+        original = getattr(settings, key)
+        setattr(settings, key, "Custom")
+        try:
+            extra_settings_conf.configure_defaults()
+            self.assertEqual(settings.EXTRA_SETTINGS_VERBOSE_NAME, "Custom")
+        finally:
+            setattr(settings, key, original)
+
+    def test_configure_defaults_is_idempotent(self):
+        extra_settings_conf.configure_defaults()
+        extra_settings_conf.configure_defaults()
+        for key, _value in EXPECTED_DEFAULTS.items():
+            with self.subTest(key=key):
+                self.assertTrue(hasattr(settings, key))


### PR DESCRIPTION
**Describe your changes**

Fixes a boot-time crash that happens when a project imports anything from the `extra_settings` package inside its Django settings module.

### The problem

A common pattern is to import the field-type enum in `settings.py` so it can be used in `EXTRA_SETTINGS_DEFAULTS`:

```python
# myproject/settings.py
from extra_settings.choices import SettingType

EXTRA_SETTINGS_DEFAULTS = [
    {"name": "FOO", "type": SettingType.STRING, "value": "bar"},
]
```

This breaks app boot with:

```
AttributeError: 'Settings' object has no attribute 'EXTRA_SETTINGS_VERBOSE_NAME'
```

**Root cause.** The library applies its `EXTRA_SETTINGS_*` defaults by mutating `django.conf.settings` as a one-shot import side effect: `extra_settings/__init__.py` does `try: from extra_settings import settings except ImproperlyConfigured: pass`, and `extra_settings/settings.py` sets each default on `django.conf.settings`.

When the package is first imported *while the settings module is still executing*, `django.conf.settings` is not ready yet. Importing `extra_settings.settings` raises `ImproperlyConfigured`, which is silently swallowed. Python drops the half-initialised `extra_settings.settings` from `sys.modules`, but the top-level `extra_settings` package stays cached — so `apps.populate()` never re-runs `__init__.py`, `extra_settings.settings` never runs again, and the defaults are **never applied for the life of the process**. `apps.py` then reads `settings.EXTRA_SETTINGS_VERBOSE_NAME` in its class body during `populate()` and crashes.

### The fix

Keep mutating `django.conf.settings` (preserves the existing public contract), but make the mechanism robust with two independent parts:

1. **Safe reads with defaults** at the import-time read sites (`apps.py`, `admin.py`): `settings.EXTRA_SETTINGS_X` becomes `get("EXTRA_SETTINGS_X")`, which falls back to the canonical default when the attribute is missing — so import can no longer hard-fail.
2. **Idempotent re-application from `AppConfig.ready()`**: `ready()` runs once after settings are configured and calls `configure_defaults()`, restoring the `EXTRA_SETTINGS_*` attributes even in the early-import scenario.

Defaults are centralised in `_CONFIG_DEFAULTS` (single source of truth), and mutable defaults are `deepcopy`-ed so they are never aliased to the canonical dict. The `__init__.py` best-effort side effect is left unchanged; its failure is now harmless.

Backward compatibility is fully preserved: `django.conf.settings.EXTRA_SETTINGS_*` are still present with identical values after boot, user-provided values are never overwritten, and no public symbols are removed.

**Related issue**

N/A

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
